### PR TITLE
Fokus på dags tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"prettier-plugin-tailwindcss": "^0.6.12",
 		"svelte": "^5.34.3",
 		"svelte-check": "^4.2.1",
+		"svelte-sonner": "^1.0.5",
 		"tailwind-merge": "^3.3.1",
 		"tailwind-variants": "^1.0.0",
 		"tailwindcss": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       svelte-check:
         specifier: ^4.2.1
         version: 4.2.1(picomatch@4.0.2)(svelte@5.34.3)(typescript@5.8.3)
+      svelte-sonner:
+        specifier: ^1.0.5
+        version: 1.0.5(svelte@5.34.3)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -1475,6 +1478,11 @@ packages:
       svelte:
         optional: true
 
+  svelte-sonner@1.0.5:
+    resolution: {integrity: sha512-9dpGPFqKb/QWudYqGnEz93vuY+NgCEvyNvxoCLMVGw6sDN/3oVeKV1xiEirW2E1N3vJEyj5imSBNOGltQHA7mg==}
+    peerDependencies:
+      svelte: ^5.0.0
+
   svelte-toolbelt@0.9.1:
     resolution: {integrity: sha512-wBX6MtYw/kpht80j5zLpxJyR9soLizXPIAIWEVd9llAi17SR44ZdG291bldjB7r/K5duC0opDFcuhk2cA1hb8g==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
@@ -2822,6 +2830,11 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.5)
       postcss-selector-parser: 7.1.0
     optionalDependencies:
+      svelte: 5.34.3
+
+  svelte-sonner@1.0.5(svelte@5.34.3):
+    dependencies:
+      runed: 0.28.0(svelte@5.34.3)
       svelte: 5.34.3
 
   svelte-toolbelt@0.9.1(svelte@5.34.3):

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,10 +6,27 @@
     import Sunday from '$lib/components/strandfest/sunday.svelte';
     import Monday from '$lib/components/strandfest/monday.svelte';
     import InfoPage from '$lib/components/strandfest/infopage.svelte';
+
+
+    let today = new Date();
+    let dayValue = 'friday';
+
+    // Get the current day of week (0 = Sunday, 1 = Monday, ..., 6 = Saturday)
+    const dayOfWeek = today.getDay();
+
+    if (dayOfWeek === 6) {
+        dayValue = 'saturday';
+    } else if (dayOfWeek === 0) {
+        dayValue = 'sunday';
+    } else if (dayOfWeek === 1) {
+        dayValue = 'monday';
+    } else {
+        dayValue = 'friday';
+    }
 </script>
-Dev
+
 <div>
-	<Tabs.Root value="friday">
+    <Tabs.Root value={dayValue}>
         <div class="mx-auto my-5 flex flex-col items-center justify-center gap-6 md:max-w-sm">
             <Tabs.List>
                 <Tabs.Trigger value="friday">Fredag 20/6</Tabs.Trigger>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
     import Monday from '$lib/components/strandfest/monday.svelte';
     import InfoPage from '$lib/components/strandfest/infopage.svelte';
 </script>
-
+Dev
 <div>
 	<Tabs.Root value="friday">
         <div class="mx-auto my-5 flex flex-col items-center justify-center gap-6 md:max-w-sm">

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "SennelsApp",
+  "short_name": "SennelsApp",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
Tilføjet javascript kode, så hvis det er lørdag eller søndag i dag, så er den dag i fokus i tabben. 